### PR TITLE
'type' no longer returned by zenodo API

### DIFF
--- a/download_data.py
+++ b/download_data.py
@@ -51,7 +51,6 @@ def gen_download_info(args: argparse.Namespace) -> dict:
             "name": filename,
             "url": item["links"]["self"],
             "size": item["size"],
-            "type": item["type"],
             "checksum": item["checksum"].split(":")[-1],
         }
 


### PR DESCRIPTION
It looks like the zenodo API has changed - the `type` field is no longer returned (but this wasn't used by the script anyway)